### PR TITLE
Psychology Compatability Fix

### DIFF
--- a/Source/FNotAgain_Mod.cs
+++ b/Source/FNotAgain_Mod.cs
@@ -93,7 +93,7 @@ namespace FNotAgain_Mod
                 foreach (Building current in list)
                 {
                     Building_CryptosleepCasket building_CryptosleepCasket = current as Building_CryptosleepCasket;
-                    if (building_CryptosleepCasket != null && building_CryptosleepCasket.HasAnyContents && building_CryptosleepCasket.ContainedThing.GetType() == typeof(Pawn))
+                    if (building_CryptosleepCasket != null && building_CryptosleepCasket.HasAnyContents && (building_CryptosleepCasket.ContainedThing.GetType() == typeof(Pawn) || building_CryptosleepCasket.ContainedThing.GetType() == typeof(Psychology.PsychologyPawn)))
                     {
                         pawnsToSave.Add((Pawn)building_CryptosleepCasket.ContainedThing);
                     }


### PR DESCRIPTION
Added OR to line 96 to allow it to search for Psychology.PsychologyPawn things. This is my first time using GitHub so I'm not sure this is the right way to go about this, but I tested the proposed change on my own machine, and it seems to work fine with no obvious errors. If I had more than about two hours of experience with this, I'd try to find a more elegant way to do it, but alas. Special thanks to erdelf#3480 on Discord for confirming my hunch about what needed to be done. For reference, a recompiled version of the DLL from my machine is attached.
[FNotAgain_Mod_PsyComp.zip](https://github.com/fyarn/FNotAgain-Mod/files/1243830/FNotAgain_Mod_PsyComp.zip)